### PR TITLE
Modifications to round export function

### DIFF
--- a/tabbie2.git/frontend/controllers/RoundController.php
+++ b/tabbie2.git/frontend/controllers/RoundController.php
@@ -493,8 +493,8 @@ class RoundController extends BasetournamentController
                     $strikedTeam = $adju->getStrikedTeams()->asArray()->all();
                     $adjudicator["strikedTeams"] = ArrayHelper::getColumn($strikedTeam, "id");
 
-                    $adjudicator["pastAdjudicatorIDs"] = $adju->getPastAdjudicatorIDs($round->id, true);
-                    $adjudicator["pastTeamIDs"] = $adju->getPastTeamIDs($round->id, true);
+                    $adjudicator["pastAdjudicatorIDs"] = $adju->getPastAdjudicatorIDsWithRoundNumbers($round->number);
+                    $adjudicator["pastTeamIDs"] = $adju->getPastTeamIDsWithRoundNumbers($round->number);
 
                     if ($inPanel->function == Panel::FUNCTION_CHAIR) {
                         array_unshift($line["panel"]["adjudicators"], $adjudicator);


### PR DESCRIPTION
Further work on #17.
- Creates list of societies as a separate list, to avoid duplicate information and provide a single location for lookup
- Includes country code for societies, and removes region information (regions will be inferred from countries in a separate lookup table in Adjumo)
- Adds round numbers to adjudicator and team history

**I haven't tested this code** because I don't know how to do so, and I'm not confident in PHP, so I'd really appreciate it if you would please vet these changes and run a sanity check on them to make sure it doesn't crash.
