### PR TITLE
Swap motion graph order to match debate layout

### DIFF
--- a/tabbie2.git/common/models/Round.php
+++ b/tabbie2.git/common/models/Round.php
@@ -1005,10 +1005,10 @@ class Round extends \yii\db\ActiveRecord
 
             $poly = Html::tag("polygon", null, [
                 "points" =>
-                    $posMatrix["og_x"] . "," . $posMatrix["og_y"] . " " .
-                    $posMatrix["oo_x"] . "," . $posMatrix["oo_y"] . " " .
-                    $posMatrix["co_x"] . "," . $posMatrix["co_y"] . " " .
-                    $posMatrix["cg_x"] . "," . $posMatrix["cg_y"],
+                    $posMatrix["og_x"] . "," . $posMatrix["og_y"] . " " . // Top-Left
+                    $posMatrix["cg_x"] . "," . $posMatrix["cg_y"] . " " . // Bottom-Left
+                    $posMatrix["co_x"] . "," . $posMatrix["co_y"] . " " . // Bottom-Right
+                    $posMatrix["oo_x"] . "," . $posMatrix["oo_y"],        // Top-Right
                 "style" => "fill:$color"
             ]);
 


### PR DESCRIPTION
Intuitively, I would have thought that the motions balance graph would follow the established way of representing debate sides, which is to say:

    OG    OO
    CG    CO

From what I can tell this is not the case, and instead it shows:

    OG    CG
    OO    CO

In my experience the first arrangement is the most commonly used in ballots and in other diagrams as it follows the physical arrangement of desks/speakers relative to the adjudicator.

I've yet to get my local copy of Tabbie2 working fully (I might create an issue or PR about installation instructions later) so this has not been fully tested. But as far as I can tell it should be a simple substitution.
