### PR TITLE
Switch references of 'tab master’ to 'tab director’ in the user interface

### DIFF
--- a/tabbie2.git/backend/views/site/index.php
+++ b/tabbie2.git/backend/views/site/index.php
@@ -3,12 +3,12 @@
 
 use yii\helpers\Html;
 
-$this->title = 'Welcome Tab Master';
+$this->title = 'Welcome Tab Director';
 ?>
 <div class="site-index">
 
 	<div class="jumbotron">
-		<h1>Welcome Tabbie2-Master!</h1>
+		<h1>Welcome Tabbie2-Director!</h1>
 
 		<p class="lead">Welcome to the Backend</p>
 	</div>

--- a/tabbie2.git/frontend/controllers/StrikeController.php
+++ b/tabbie2.git/frontend/controllers/StrikeController.php
@@ -48,7 +48,7 @@ class StrikeController extends BasetournamentController
                     ],
                 ],
                 'denyCallback' => function ($rule, $action) {
-                    Yii::$app->session->setFlash("error", "403: " . Yii::t("app", "Only authorised Tabmasters can access this function"));
+                    Yii::$app->session->setFlash("error", "403: " . Yii::t("app", "Only authorised Tab Directors can access this function"));
                     return $this->goBack(Yii::$app->request->referrer);
                 },
             ],

--- a/tabbie2.git/frontend/views/tournament/_form.php
+++ b/tabbie2.git/frontend/views/tournament/_form.php
@@ -154,7 +154,7 @@ SCRIPT;
 			],
 		],
 		'options'       => [
-			'placeholder' => Yii::t("app", 'Choose your Tabmaster ...'),
+			'placeholder' => Yii::t("app", 'Choose your Tab Director ...'),
 		],
 		'pluginOptions' => [
 			'multiple'           => true,

--- a/tabbie2.git/frontend/views/tournament/_view_tournamentinfo.php
+++ b/tabbie2.git/frontend/views/tournament/_view_tournamentinfo.php
@@ -20,7 +20,7 @@ echo DetailView::widget([
         ],
         [
             "attribute" => 'tabmaster',
-            'label' => "Tab Master",
+            'label' => "Tab Director",
             'format' => 'raw',
             'value' => implode(", ", \yii\helpers\ArrayHelper::getColumn($model->tabmasters, "name")),
         ],

--- a/tabbie2.git/frontend/views/tournament/_view_tournamentinfo.php
+++ b/tabbie2.git/frontend/views/tournament/_view_tournamentinfo.php
@@ -20,7 +20,7 @@ echo DetailView::widget([
         ],
         [
             "attribute" => 'tabmaster',
-            'label' => "Tab Director",
+            'label' => "Tab Team",
             'format' => 'raw',
             'value' => implode(", ", \yii\helpers\ArrayHelper::getColumn($model->tabmasters, "name")),
         ],


### PR DESCRIPTION
Many circuits have largely moved away from referring to tab 'masters' because of the gendered and outdated nature of that word. My personal preference is for 'director' but it is a weak one. 

I hope that the language involved in tabbing should reflect the norms of debating, and perhaps in places lean towards the more progressive side of those norms given our (relatively) prominent positions at tournaments and the lack of diversity often present within tabbing. Given Tabbie2's high visibility in BP circuits I belive changing this wording would be a minor, but valuable signal.

Obviously as maintainer @JakobReiter has final say, but I would hope that this discussion and decision could involve the broader community. I know several people with positions on this issue, however I'm posting this PR as a standalone item so that Jakob can dictate how and where this discussion could take place — a github PR may not be the most visible or accessible forum. Perhaps somewhere on Facebook, say the [Tabbie 2 page](https://www.facebook.com/TabbieTwo/?fref=ts) or one of the larger discussion groups such as [Communist Case File](https://www.facebook.com/groups/communistcasefile/) or  [WUDC Chat](https://www.facebook.com/groups/734360609907768/)?