### PR TITLE
Fix Chrome CSS issue 

### DIFF
--- a/tabbie2.git/console/controllers/SampledataController.php
+++ b/tabbie2.git/console/controllers/SampledataController.php
@@ -39,9 +39,9 @@ class SampledataController extends Controller
 // use the factory to create a Faker\Generator instance
 		$faker = Faker\Factory::create();
 
-		$output_venue = "Name;Active;Group\n";
-		$output_teams = "Team Name;Society Name;A.Givenname;A.Surename;A.Email;B.Givenname;B.Surename;B.Email\n";
-		$output_adjudicator = "Society;Givenname;Surename;Email;Strength\n";
+		$output_venue = "Name,Active,Group\n";
+		$output_teams = "Team Name,Society Name,A.Givenname,A.Surename,A.Email,B.Givenname,B.Surename,B.Email\n";
+		$output_adjudicator = "Society,Givenname,Surename,Email,Strength\n";
 		$save = [];
 
 		echo "\nVenues:";

--- a/tabbie2.git/frontend/assets/css/color_pattern.css
+++ b/tabbie2.git/frontend/assets/css/color_pattern.css
@@ -2,8 +2,8 @@
  * Regions
  */
 
-.region {
-    background-color: #000000
+.region .adj {
+    background-color: #CCC; /* Add gray backgronud for region-less adjs */
 }
 
 /* Europe */

--- a/tabbie2.git/frontend/assets/csv/Import_Adjudicator.csv
+++ b/tabbie2.git/frontend/assets/csv/Import_Adjudicator.csv
@@ -1,1 +1,1 @@
-Society;Givenname;Surename;Email;Strength
+Society,Givenname,Surename,Email,Strength

--- a/tabbie2.git/frontend/assets/csv/Import_Team.csv
+++ b/tabbie2.git/frontend/assets/csv/Import_Team.csv
@@ -1,1 +1,1 @@
-Team Name;Society Name;A.Givenname;A.Surename;A.Email;B.Givenname;B.Surename;B.Email
+Team Name,Society Name,A.Givenname,A.Surename,A.Email,B.Givenname,B.Surename,B.Email

--- a/tabbie2.git/frontend/assets/csv/Import_Venue.csv
+++ b/tabbie2.git/frontend/assets/csv/Import_Venue.csv
@@ -1,1 +1,1 @@
-Name;Active;Group
+Name,Active,Group


### PR DESCRIPTION
Where region-less adjudicator names are obscured by a black background + fix regression where black strips show when region highlights enabled. A follow up to the issues noted on [this commit](https://github.com/JakobReiter/Tabbie2/commit/1107c98382b576e150937bdac795ef4ae971ba8c)