### PR TITLE
Improve motion balance diagram readability

### DIFF
--- a/tabbie2.git/common/models/Round.php
+++ b/tabbie2.git/common/models/Round.php
@@ -1043,6 +1043,29 @@ class Round extends \yii\db\ActiveRecord
                     (3 * $quarter) . "," . $quarter,
                 "style" => "fill:transparent; stroke:$gray; stroke-width:1"
             ]);
+
+            $labelattributes = [
+                "font-size" => "12",
+                "fill" => "#999",
+                "font-family" => "Helvetica Neue, Helvetica, Arial, sans-serif"
+            ];
+            $labelog = Html::tag("text", 'OG', array_merge([
+                "x" => 4,
+                "y" => 15,
+            ], $labelattributes));
+            $labeloo = Html::tag("text", 'OO', array_merge([
+                "x" => 4,
+                "y" => $size - 6
+            ], $labelattributes));
+            $labelcg = Html::tag("text", 'CG', array_merge([
+                "x" => $size - 22,
+                "y" => 15,
+            ], $labelattributes));
+            $labelco = Html::tag("text", 'CO', array_merge([
+                "x" => $size - 22,
+                "y" => $size - 6,
+            ], $labelattributes));
+
             $out = Html::tag("polygon", null, [
                 "points" => "0,0 " .
                     "0,$size " .
@@ -1051,7 +1074,8 @@ class Round extends \yii\db\ActiveRecord
                 "style" => "fill:transparent; stroke:$gray; stroke-width:1"
             ]);
 
-            $html = Html::tag("svg", $poly . $horizon . $vertik . $medium . $out, [
+            $html = Html::tag("svg", $poly . $horizon . $vertik . $medium .
+                                     $labelog . $labeloo . $labelcg . $labelco . $out, [
                 "viewBox" => "0 0 $size $size",
                 "width" => $size,
                 "height" => $size,

--- a/tabbie2.git/common/models/Round.php
+++ b/tabbie2.git/common/models/Round.php
@@ -964,7 +964,7 @@ class Round extends \yii\db\ActiveRecord
                 "WHERE tournament_id = " . $this->tournament->id . " AND round_id=" . $this->id
         ]);
 
-        $html = Yii::$app->cache->get($key);
+        // $html = Yii::$app->cache->get($key);
         if (!$html) {
 
             $posMatrix = [
@@ -1003,13 +1003,13 @@ class Round extends \yii\db\ActiveRecord
                 }
                 $posMatrix["og_x"] = $posMatrix["og_y"] = $base * (1 - $posMatrix["og_percent"]);
 
-                $posMatrix["oo_x"] = $base * (1 - $posMatrix["oo_percent"]);
-                $posMatrix["oo_y"] = $base * ($posMatrix["oo_percent"]) + $base;
+                $posMatrix["oo_x"] = $base * ($posMatrix["oo_percent"]) + $base;
+                $posMatrix["oo_y"] = $base * (1 - $posMatrix["oo_percent"]);
 
                 $posMatrix["co_x"] = $posMatrix["co_y"] = $base * ($posMatrix["co_percent"]) + $base;
 
-                $posMatrix["cg_x"] = $base * ($posMatrix["cg_percent"]) + $base;
-                $posMatrix["cg_y"] = $base * (1 - $posMatrix["cg_percent"]);
+                $posMatrix["cg_x"] = $base * (1 - $posMatrix["cg_percent"]);
+                $posMatrix["cg_y"] = $base * ($posMatrix["cg_percent"]) + $base;
             }
 
             $poly = Html::tag("polygon", null, [
@@ -1053,11 +1053,11 @@ class Round extends \yii\db\ActiveRecord
                 "x" => 4,
                 "y" => 15,
             ], $labelattributes));
-            $labeloo = Html::tag("text", 'OO', array_merge([
+            $labelcg = Html::tag("text", 'CG', array_merge([
                 "x" => 4,
                 "y" => $size - 6
             ], $labelattributes));
-            $labelcg = Html::tag("text", 'CG', array_merge([
+            $labeloo = Html::tag("text", 'OO', array_merge([
                 "x" => $size - 22,
                 "y" => 15,
             ], $labelattributes));


### PR DESCRIPTION
The first commit adds small unobtrusive labels in the corners of the motion balance diagram to more easily identify which team the polygon is 'pointing' to. 

The second commit re-orients the diagram (and labels) to match the layout of a ballot and the spatial layout of a debate which I think is the more intuitive way of reading the diagram. That said this is a break to how users are used to the diagram working (but the labels should help clarify this). If this change is undesirable feel free to cherry pick just the first commit.

[This image](https://www.dropbox.com/s/4dgmpg5x14lnwuf/tabbie2diagram.png?dl=0) shows the effects of commit 1 on the left and commit 1+2 on the right. While the polygon can overlap with the labels in a manner that doesn't look super great motion balance shouldn't be that bad outside of the odd out-round so this should be relatively rare. 

This has been tested on a local copy.