### PR TITLE
GDPR Consent

### DIFF
--- a/tabbie2.git/common/models/User.php
+++ b/tabbie2.git/common/models/User.php
@@ -37,6 +37,7 @@ use yii\web\IdentityInterface;
  * @property string $picture
  * @property string $time
  * @property string $language
+ * @property string $gdprconsent
  * @property Adjudicator[] $adjudicators
  * @property InSociety[] $inSocieties
  * @property Society[] $societies
@@ -70,6 +71,9 @@ class User extends ActiveRecord implements IdentityInterface
     const LANGUAGE_INTERVIEW = 4;
     const LANGUAGE_MIXED = -1;
     const LANGUAGE_NOVICE = -2;
+
+    const GDPR_NONE = 0;
+    const GDPR_CONSENT = 1;
 
     const NONE = "(not set)";
 
@@ -258,6 +262,14 @@ class User extends ActiveRecord implements IdentityInterface
         ];
     }
 
+		public static function gdprOptions()
+		{
+			return [
+				self::GDPR_NONE => Yii::t("app", "Not consenting"),
+				self::GDPR_CONSENT => Yii::t("app", "Consenting"),
+			];
+		}
+
     public static function generatePlaceholder($tournament_slug)
     {
         $swing_User = User::find()->where(["LIKE", "url_slug", $tournament_slug])->orderBy(["id" => SORT_DESC])->one();
@@ -277,6 +289,7 @@ class User extends ActiveRecord implements IdentityInterface
             "email" => "speaker." . $letter . "@" . $tournament_slug . ".tabbie.com",
             "role" => User::ROLE_PLACEHOLDER,
             "status" => User::STATUS_ACTIVE,
+            "gdprconsent" => User::GDPR_CONSENT,
             "last_change" => date("Y-m-d H:i:s"),
             "time" => date("Y-m-d H:i:s"),
         ]);
@@ -306,6 +319,15 @@ class User extends ActiveRecord implements IdentityInterface
     {
         $this->auth_key = Yii::$app->security->generateRandomString();
     }
+
+    public static function getGPDRStatusLabel($id){
+    	$status = [
+    		self::GDPR_NONE => Yii::t("app", 'Not Consented'),
+    		self::GDPR_CONSENT => Yii::t("app", 'Consented'),
+			];
+
+			return $status[$id];
+		}
 
     public static function getLanguageStatusLabel($id = null, $short = false)
     {
@@ -507,7 +529,7 @@ class User extends ActiveRecord implements IdentityInterface
             [['password', 'password_repeat'], 'string', 'on' => 'first_login'],
             [['password', 'password_repeat'], 'required', 'on' => 'first_login'],
 
-            [['id', 'role', 'status', 'language_status', 'language_status_by_id'], 'integer'],
+            [['id', 'role', 'status', 'language_status', 'language_status_by_id', 'gdprconsent'], 'integer'],
             [['picture'], 'string'],
             [['url_slug', 'password_hash', 'password_reset_token', 'email', 'givenname', 'surename'], 'string', 'max' => 255],
 
@@ -524,10 +546,13 @@ class User extends ActiveRecord implements IdentityInterface
             ['gender', 'default', 'value' => self::GENDER_NOTREVEALING],
             ['gender', 'in', 'range' => [self::GENDER_MALE, self::GENDER_FEMALE, self::GENDER_OTHER, self::GENDER_NOTREVEALING]],
 
+						['gdprconsent', 'default', 'value' => self::GDPR_CONSENT],
+            ['gdprconsent', 'in', 'range' => [self::GDPR_NONE, self::GDPR_CONSENT]],
+
             ['language_status', 'default', 'value' => self::LANGUAGE_NONE],
             ['language_status', 'in', 'range' => [self::LANGUAGE_NONE, self::LANGUAGE_ENL, self::LANGUAGE_ESL, self::LANGUAGE_EFL, self::LANGUAGE_INTERVIEW, self::LANGUAGE_NOVICE]],
 
-            [['password', 'password_repeat', 'url_slug', 'language', 'time', 'last_change', 'societies_id', 'language_status_update'], 'safe'],
+            [['password', 'password_repeat', 'url_slug', 'language', 'time', 'last_change', 'societies_id', 'language_status_update', 'gdprconsent'], 'safe'],
         ];
     }
 
@@ -563,6 +588,7 @@ class User extends ActiveRecord implements IdentityInterface
             'language_status' => Yii::t('app', 'Language Status'),
             'picture' => Yii::t('app', 'Picture'),
             'time' => Yii::t('app', 'Time'),
+            'gdprconsent' => Yii::t('app', 'GDPR Consent'),
         ];
     }
 

--- a/tabbie2.git/console/migrations/m180508_092051_addgdprconsent.php
+++ b/tabbie2.git/console/migrations/m180508_092051_addgdprconsent.php
@@ -1,0 +1,16 @@
+<?php
+
+use yii\db\Migration;
+
+class m180508_092051_addgdprconsent extends Migration
+{
+	public function up()
+	{
+		$this->addColumn('user', 'gdprconsent', $this->integer()."(11) DEFAULT 0");
+	}
+
+	public function down()
+	{
+		$this->dropColumn('user', 'gdprconsent');
+	}
+}

--- a/tabbie2.git/frontend/views/site/index.php
+++ b/tabbie2.git/frontend/views/site/index.php
@@ -72,6 +72,18 @@ $this->title = Yii::$app->params["slogan"];
 				<?= Html::a(Html::icon("plus") . "&nbsp;" . Yii::t("app", "Create Tournament"), ['tournament/create'], ["class" => "btn btn-lg btn-success btn-block"]) ?>
 			</div>
 		</div>
+    <? if (!Yii::$app->user->isGuest && Yii::$app->user->identity->gdprconsent != 1): ?>
+        <div class="row">
+            <div class="col-xs-12 hidden-sm col-md-2 col-lg-2">
+                &nbsp;
+            </div>
+        </div>
+        <div class="row">
+          <div class="col">
+            <?= Html::a(\kartik\helpers\Html::icon("cog") . "&nbsp" . Yii::t('app', 'Update GDPR Settings'), ['/user/update', 'id' => Yii::$app->user->id], ['class' => 'btn btn-primary btn-danger']) ?>
+          </div>
+        </div>
+    <? endif; ?>
 	</div>
 
 	<div class="body-content">

--- a/tabbie2.git/frontend/views/user/_form.php
+++ b/tabbie2.git/frontend/views/user/_form.php
@@ -57,8 +57,10 @@ use yii\web\JsExpression;
 		<div class="col-sm-6">
 			<?= $form->field($model, 'gender')->dropDownList(\common\models\User::genderOptions()) ?>
 		</div>
-		<div class="col-sm-6 col-sm-push-4">
-            <? //echo $form->field($model, 'language')->dropDownList(\common\models\User::languageOptions()) ?>
+        <div class="col-sm-6">
+        </div>
+		<div class="col-sm-6">
+            <? echo $form->field($model, 'gdprconsent')->dropDownList(\common\models\User::gdprOptions()) ?>
 		</div>
 	</div>
 

--- a/tabbie2.git/frontend/views/user/view.php
+++ b/tabbie2.git/frontend/views/user/view.php
@@ -33,6 +33,10 @@ $this->params['breadcrumbs'][] = $this->title;
                     'name',
                     'email:email',
                     [
+                        'label' => Yii::t("app", "GDPR Consent"),
+                        'value' => \common\models\User::getGPDRStatusLabel($model->gdprconsent)
+                    ],
+                    [
                         'label' => Yii::t("app", "Language Status"),
                         'value' => \common\models\User::getLanguageStatusLabel($model->language_status)
                     ],


### PR DESCRIPTION
**What is the 'General Data Protection Regulation (GDPR)’?**
The General Data Protection Regulation (GDPR) is a legal framework that sets guidelines for the collection and processing of personal information of individuals within the European Union. The GDPR sets out the principles for data management and the rights of the individual, while also imposing fines that can be revenue-based. While Tabbie doesn’t make any revenue, we are still covered, and we are seeking to adopt best practices. The General Data Protection Regulation covers all companies that deal with data of EU citizens, and will come into effect across the EU on May 25, 2018.

**Why do we want your consent?**
First and foremost to publish tabs, so that people can see the information relating to your performance in previous competitions.
Secondly, to do large-scale analysis over competitions, so that we can track performance between competitions.
For example, using the proposal made by Ashish and MDG in the MDR (http://mdr.monashdebaters.com/volume-12-2014/introducing-elo-ratings-in-british-parliamentary-debating/) we have been able to create a rudimentary rating system to discover who has been the best BP debater in the world by Tabbie rating since 2015 (the list will be published if and when I receive the consent of all of the #1s (they know who they are)).

**How do you consent?**
Log into your Tabbie account, and click on the button:
￼
You will be taken to your ‘edit data’ page, where you can give your consent:
￼
If you don’t wish to give your consent, that’s fine. We will erase all of the data associated with your account (including, but not limited to, name, gender preferences, institutional history, clash lists, previous tab performance and email) the day before GDPR comes into effect. This will have the effect of retroactively erasing this data from all past tabs on the website.