### PR TITLE
Single swing speaker team point change

### DIFF
--- a/tabbie2.git/common/models/Result.php
+++ b/tabbie2.git/common/models/Result.php
@@ -205,7 +205,7 @@ class Result extends \yii\db\ActiveRecord {
 	 * @return int
 	 */
 	public function getPoints($p) {
-		if ($this->{$p . "_irregular"} > Team::IRREGULAR_NORMAL) {
+		if ($this->{$p . "_irregular"} == Team::IRREGULAR_SWING) {
 			return 0;
 		}
 


### PR DESCRIPTION
If 1 or fewer speakers opt out of a round, the team should be awarded the full team points earned. On Team Tab, points will be marked with an asterisk to identify swing speakers were in the round.