### PR TITLE
Fix insecure queries

### DIFF
--- a/tabbie2.git/common/models/search/AdjudicatorSearch.php
+++ b/tabbie2.git/common/models/search/AdjudicatorSearch.php
@@ -121,10 +121,14 @@ class AdjudicatorSearch extends Adjudicator
 
         // filter by user name
         if ($this->name)
-            $query->andWhere('CONCAT(user.givenname, " ", user.surename) LIKE "%' . $this->name . '%"');
+            $query->andWhere('CONCAT(user.givenname, " ", user.surename) LIKE CONCAT("%", :name, "%")', [
+                ':name' => $this->name
+            ]);
 
         if ($this->societyName)
-            $query->andWhere('society.fullname LIKE "%' . $this->societyName . '%"');
+            $query->andWhere('society.fullname LIKE CONCAT("%", :societyName, "%")', [
+                ':societyName' => $this->societyName
+            ]);
 
         return $dataProvider;
     }

--- a/tabbie2.git/common/models/search/DebateSearch.php
+++ b/tabbie2.git/common/models/search/DebateSearch.php
@@ -122,10 +122,12 @@ class DebateSearch extends Debate
 			'time'          => $this->time,
 		]);
 
-		$query->andWhere("ogteam.name LIKE '%" . $params["DebateSearch"]["team"] . "%' OR " .
-			"ooteam.name LIKE '%" . $params["DebateSearch"]["team"] . "%' OR " .
-			"cgteam.name LIKE '%" . $params["DebateSearch"]["team"] . "%' OR " .
-			"coteam.name LIKE '%" . $params["DebateSearch"]["team"] . "%'"
+		$query->andWhere('ogteam.name LIKE CONCAT("%", :team, "%") OR ' .
+			'ooteam.name LIKE CONCAT("%", :team, "%") OR ' .
+			'cgteam.name LIKE CONCAT("%", :team, "%") OR ' .
+			'coteam.name LIKE CONCAT("%", :team, "%")', [
+                'team' => $params["DebateSearch"]["team"]
+			    ]
 		);
 
 		if ($this->language_status)


### PR DESCRIPTION
Let Yii deal with potential bad guys by passing user input to it as a parameter. This ensures proper sanitisation. The excessive use of `CONCAT` is necessary so Yii doesn't recognise the `%` symbols as parameters.