### PR TITLE
Implement a DebateXML exporter

### DIFF
--- a/tabbie2.git/common/components/ArchiveExport.php
+++ b/tabbie2.git/common/components/ArchiveExport.php
@@ -1,0 +1,242 @@
+<?php
+	/**
+	 * ArchiveExport.php File
+	 * @package  Tabbie2
+	 * @author   Étienne Beaulé
+	 * @version
+	 */
+
+	namespace common\components;
+
+
+	use yii;
+	use yii\base\Component;
+	use common\models;
+
+	class ArchiveExport extends Component
+	{
+		const BREAK_CAT_PREFIX = 'BC';
+		const DEBATE_PREFIX = 'D';
+		const VENUE_PREFIX = 'V';
+		const MOTION_PREFIX = 'M';
+		const TEAM_PREFIX = 'T';
+		const SPEAKER_PREFIX = 'S';
+		const SOCIETY_PREFIX = 'I';
+		const ADJ_PREFIX = 'A';
+		const QUESTION_PREFIX = 'Q';
+
+		public function createXML($tournament)
+		{
+			$xml = new \SimpleXMLElement(
+				'<tournament style="bp" />'
+			);
+			$xml->addAttribute('name', $tournament->fullname);
+			$xml->addAttribute('short', $tournament->name);
+			$xml->addAttribute('host', $tournament->hostedby->fullname);
+			$xml->addAttribute('start-date', $tournament->start_date);
+			$xml->addAttribute('end-date', $tournament->end_date);
+
+			foreach ($tournament->rounds as $round)
+			{
+				$roundXML = $xml->addChild('round');
+				$roundXML->addAttribute('name', $round->getName());
+				$isInround = $round->type == models\Round::TYP_IN;
+				$roundXML->addAttribute('elimination', $isInround ? 'false' : 'true');
+				if (!$isInround) $roundXML->addAttribute('break-category', self::BREAK_CAT_PREFIX . $round->type);
+
+				foreach ($round->debates as $debate)
+				{
+					$result = $debate->result;
+					$debateXML = $roundXML->addChild('debate');
+					$debateXML->addAttribute('id', self::DEBATE_PREFIX . $debate->id);
+					$debateXML->addAttribute('venue', self::VENUE_PREFIX . $debate->venue_id);
+					$debateXML->addAttribute('motion', self::MOTION_PREFIX . $round->id);
+
+					list($adjs, $chair) = self::getAdjudicatorsString($debate);
+					$debateXML->addAttribute('adjudicators', $adjs);
+					$debateXML->addAttribute('chair', $chair);
+
+					foreach ($debate->getTeams() as $k => $team)
+					{
+						$sideXML = $debateXML->addChild('side');
+						$sideXML->addAttribute('team', self::TEAM_PREFIX . $team->id);
+
+						$sideBallotXML = $sideXML->addChild('ballot', $result->getSpeaks($k));
+
+						$sideBallotXML->addAttribute('adjudicators', $adjs);
+						$sideBallotXML->addAttribute('ignored', 'false');
+						$sideBallotXML->addAttribute('rank', $result->{$k . '_place'});
+
+						foreach (['A', 'B'] as &$speaker)
+						{
+							$speechXML = $sideXML->addChild('speech');
+							$speechXML->addAttribute('reply', 'false');
+
+							$ballotXML = $speechXML->addChild('ballot', $result->{$k . '_' . $speaker . '_speaks'});
+							$ballotXML->addAttribute('adjudicators', $adjs);
+
+							# Test for iron-people to keep the correct speaker listed
+							$irregularKey = $k . '_irregular';
+							if ($speaker == 'A' && $result->$irregularKey == models\Team::IRREGULAR_A_NOSHOW) $speaker = 'B';
+							if ($speaker == 'B' && $result->$irregularKey == models\Team::IRREGULAR_B_NOSHOW) $speaker = 'A';
+							$speechXML->addAttribute('speaker', self::SPEAKER_PREFIX . $team->{'speaker' . $speaker . '_id'});
+						}
+					}
+				}
+			}
+
+
+			$participantsXML = $xml->addChild('participants');
+			$allInstitutions = [];
+
+			foreach ($tournament->teams as $team)
+			{
+				$teamXML = $participantsXML->addChild('team');
+				$teamXML->addAttribute('id', $team->id);
+				$teamXML->addAttribute('name', $team->name);
+				$teamXML->addAttribute('swing', $team->isSwing ? 'true' : 'false');
+
+				$breaks = [self::BREAK_CAT_PREFIX . models\User::LANGUAGE_ENL];
+				if ($team->language_status == models\User::LANGUAGE_ESL && $tournament->has_esl)
+					array_push($breaks, self::BREAK_CAT_PREFIX . models\User::LANGUAGE_ESL);
+				if ($team->language_status == models\User::LANGUAGE_EFL && $tournament->has_efl)
+					array_push($breaks, self::BREAK_CAT_PREFIX . models\User::LANGUAGE_EFL);
+				if ($team->language_status == models\User::LANGUAGE_EFL && $tournament->has_esl)
+					array_push($breaks, self::BREAK_CAT_PREFIX . models\User::LANGUAGE_ESL);
+				$teamXML->addAttribute('break-eligibilities', join(' ', $breaks));
+
+				foreach (['A', 'B'] as $speaker)
+				{
+					$user = $team->{'speaker' . $speaker};
+
+					$userXML = $teamXML->addChild('speaker', $user->getName());
+					$userXML->addAttribute('id', self::SPEAKER_PREFIX . $user->id);
+
+					$institutions = ['I'. $team->society_id];
+					foreach ($user->getCurrentSocieties() as $inst)
+					{
+						array_push($institutions, self::SOCIETY_PREFIX . $inst->id);
+						array_push($allInstitutions, $inst);
+					}
+					$userXML->addAttribute('institutions', join(' ', array_unique($institutions)));
+				}
+			}
+
+			$cores = [];
+			foreach ($tournament->cAs as $ca) array_push($cores, $ca->id);
+
+			foreach ($tournament->adjudicators as $adjudicator)
+			{
+				$institutions = [];
+				foreach ($adjudicator->getSocieties() as $inst)
+				{
+					array_push($institutions, self::SOCIETY_PREFIX . $inst->id);
+					array_push($allInstitutions, $inst);
+				}
+				$adjXML = $participantsXML->addChild('adjudicator');
+				$adjXML->addAttribute('id', self::ADJ_PREFIX . $adjudicator->id);
+				$adjXML->addAttribute('core', in_array($adjudicator->user_id, $cores) ? 'true' : 'false');
+				$adjXML->addAttribute('score', $adjudicator->strength);
+				$adjXML->addAttribute('institutions', join(' ', $institutions));
+				$adjXML->addAttribute('name', $adjudicator->user->getName());
+
+				$feedbacks = $adjudicator->hasMany(models\Feedback::className(), ['to_id' => 'id']);
+				foreach ($feedbacks as $fb)
+				{
+					$feedbackXML = $adjXML->addChild('feedback');
+					$feedbackXML->addAttribute('debate', self::DEBATE_PREFIX . $fb->debate_id);
+					if ($fb->to_type == models\Feedback::TO_CHAIR_FROM_TEAM)
+						$feedbackXML->addAttribute('source-team', self::TEAM_PREFIX . $fb->to_id);
+					else
+						$feedbackXML->addAttribute('source-adjudicator', self::ADJ_PREFIX . $fb->to_id);
+
+					foreach ($fb->answers as $answer)
+					{
+						$answerXML = $feedbackXML->addChild('answer', $answer->value);
+						$answerXML->addAttribute('question', self::QUESTION_PREFIX . $answer->question_id);
+					}
+				}
+			}
+
+
+			// The break categories (language status) corresponds between User::LANGUAGE_ and Round::TYP_
+			$bcXML = $xml->addChild('break-category', Yii::t("app", "Open"));
+			$bcXML->addAttribute('id', self::BREAK_CAT_PREFIX . models\Round::TYP_OUT);
+			if ($tournament->has_esl)
+			{
+				$bcXML = $xml->addChild('break-category', Yii::t("app", "ESL"));
+				$bcXML->addAttribute('id', self::BREAK_CAT_PREFIX . models\Round::TYP_ESL);
+			}
+			if ($tournament->has_efl)
+			{
+				$bcXML = $xml->addChild('break-category', Yii::t("app", "EFL"));
+				$bcXML->addAttribute('id', self::BREAK_CAT_PREFIX . models\Round::TYP_EFL);
+			}
+
+
+			foreach ($allInstitutions as $inst)
+			{
+				$instXML = $xml->addChild('institution', $inst->name);
+				$instXML->addAttribute('id', $inst->id);
+				$instXML->addAttribute('reference', $inst->abr);
+				$instXML->addAttribute('region', $inst->country->name);
+			}
+
+
+			foreach ($tournament->rounds as $round)
+			{
+				$motionXML = $xml->addChild('motion', $round->motion);
+				$motionXML->addAttribute('id', self::MOTION_PREFIX . $round->id);
+				$motionXML->addAttribute('reference', $round->motionTags[0]->name);
+
+				if ($round->infoslide !== NULL)
+					$infoslide = $motionXML->addChild('info-slide', $round->infoslide);
+			}
+
+
+			foreach ($tournament->venues as $venue)
+			{
+				$venueXML = $xml->addChild('venue', $venue->name);
+				$venueXML->addAttribute('id', self::VENUE_PREFIX . $venue->id);
+				if ($venue->group !== NULL)
+					$venueXML->addAttribute('categories', $venue->group);
+			}
+
+
+			$questionTypes = [
+				models\Question::TYPE_STAR => 'is',
+				models\Question::TYPE_INPUT => 't',
+				models\Question::TYPE_TEXT => 'tl',
+				models\Question::TYPE_NUMBER => 'f',
+				models\Question::TYPE_CHECKBOX => 'bc'
+			];
+			foreach ($tournament->getAllQuestions() as $question)
+			{
+				if ($question !== NULL)
+				{
+					$questionXML = $xml->addChild('question', $question->text);
+					$questionXML->addAttribute('id', self::QUESTION_PREFIX . $question->id);
+					if ($question->type !== NULL)
+						$questionXML->addAttribute('type', $questionTypes[$question->type]);
+					$questionXML->addAttribute('from-teams', $question->apply_T2C ? 'true' : 'false');
+					$questionXML->addAttribute('from-adjudicators', $question->apply_W2C || $question->apply_C2W ? 'true' : 'false');
+				}
+				else break;
+			}
+
+			return $xml->asXML();
+		}
+
+		private static function getAdjudicatorsString($debate) {
+			$chair = '';
+			$adjs = [];
+
+			foreach ($debate->getAdjudicatorsInPanel() as $adj)
+			{
+				$adjID = self::ADJ_PREFIX . $adj->adjudicator_id;
+				array_push($adjs, $adjID);
+				if ($adj->is_chair()) $chair = $adjID;
+			}
+			return [join(' ', $adjs), $chair];
+		}
+	}

--- a/tabbie2.git/common/models/Tournament.php
+++ b/tabbie2.git/common/models/Tournament.php
@@ -648,6 +648,15 @@ class Tournament extends \yii\db\ActiveRecord
             ->where(["apply_" . $field => 1]);
     }
 
+    /**
+     * @return \yii\db\ActiveQuery
+     */
+    public function getAllQuestions()
+    {
+        return $this->hasMany(Question::className(), ['id' => 'questions_id'])
+            ->viaTable('tournament_has_question', ['tournament_id' => 'id']);
+    }
+
     public function getSocieties()
     {
         return $this->hasMany(Society::className(), ['id' => 'society_id'])

--- a/tabbie2.git/frontend/controllers/TournamentController.php
+++ b/tabbie2.git/frontend/controllers/TournamentController.php
@@ -5,6 +5,7 @@ namespace frontend\controllers;
 use common\components\filter\TournamentContextFilter;
 use common\components\ObjectError;
 use common\components\TabbieExport;
+use common\components\ArchiveExport;
 use common\models;
 use common\models\search\TournamentSearch;
 use common\models\Tournament;
@@ -51,7 +52,7 @@ class TournamentController extends BasetournamentController {
 					],
 					[
 						'allow'         => true,
-						'actions'       => ['migrate-tabbie', 'download-sql'],
+						'actions'       => ['migrate-tabbie', 'download-sql', 'export-xml'],
 						'matchCallback' => function ($rule, $action) {
 							return ($this->_tournament->isTabMaster(Yii::$app->user->id));
 						}
@@ -419,6 +420,28 @@ class TournamentController extends BasetournamentController {
 
         $export = new TabbieExport();
         echo implode("\n", $export->generateSQL($this->_tournament));
+        exit();
+    }
+
+    /**
+     * Export tournament as an Debate XML file
+     *
+     * @param    integer $id
+     */
+    public function actionExportXml($id)
+    {
+        /** Make output UTF-8 */
+        mb_internal_encoding('UTF-8');
+        mb_http_output('UTF-8');
+        mb_http_input('UTF-8');
+        mb_language('uni');
+        mb_regex_encoding('UTF-8');
+        ob_start('mb_output_handler');
+        header('Content-Type: text/xml');
+        header('Content-Disposition: attachment; filename=' . basename($this->_tournament->name) . ' - ' . date("Y-m-d H:i:s") . '.xml');
+
+        $export = new ArchiveExport();
+        echo $export->createXML($this->_tournament);
         exit();
     }
 

--- a/tabbie2.git/frontend/views/layouts/_nav_tabmaster.php
+++ b/tabbie2.git/frontend/views/layouts/_nav_tabmaster.php
@@ -73,12 +73,13 @@ $tournament_items = [
         'linkOptions' => ['data' => [
             "confirm" => Yii::t("app", "Are you sure you want to reset the checkin?")
         ]]] : ""),
-    (($tournament->status < Tournament::STATUS_CLOSED) ? '<li class="divider"></li>' : ""),
+    ('<li class="divider"></li>'),
     (($tournament->status < Tournament::STATUS_CLOSED) ? ['label' => Html::icon("transfer") . "&nbsp;" . Yii::t('app', 'Sync with DebReg'), 'url' => ["tournament/debreg-sync", "id" => $tournament->id]] : ""),
     (($tournament->status < Tournament::STATUS_CLOSED) ? ['label' => Html::icon("export") . "&nbsp;" . Yii::t('app', 'Migrate to Tabbie 1'), 'url' => ["tournament/migrate-tabbie", "id" => $tournament->id],
         'linkOptions' => ['data' => [
             "confirm" => Yii::t("app", "Extreme caution young padawan!")
         ]]] : ""),
+    (['label' => Html::icon("export") . "&nbsp;" . Yii::t('app', 'Export DebateXML'), 'url' => ["tournament/export-xml", "id" => $tournament->id]]),
 ];
 
 


### PR DESCRIPTION
DebateXML is an interchange and archival format for debate tournaments of multiple styles, including BP.

This commit adds a quick DebateXML exporter function to tournament tab-masters, which is also available after the tournament closes. The link is available under the Tournament drop-down with the Tabbie1/DebReg integrations.

A helper function was also added to the tournament model to fetch all questions at once, rather than just a type thereof. Further, novice status was not implemented in the exporter as it does not seem to be complete.

I have not measured the performance of the exporter as I do not have a dataset to work with. It would be good if one were available for development/tests.

Schema: TabbycatDebate/dta-spec#4 (and more information about the project available in the repo)